### PR TITLE
Added a check script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,98 @@
-# https://github.com/SUSE/style-guides/blob/master/Ruby.md#strings
+# NOTE: This is a copy from https://github.com/yast/yast-devtools/blob/master/ytools/y2tool/rubocop_yast_style.yml
+
+################################################################################
+#
+# This part contains the shared Rubocop configuration for SUSE projects. It is
+# maintained at https://github.com/SUSE/style-guides/blob/master/rubocop-suse.yml
+#
+# NOTE: some rules have been commented out, see the YaST specific changes
+#       at the end of the file!
+#
+################################################################################
+
+# Disabled, would require too many changes in the current code
+#Lint/EndAlignment:
+# StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#lintendalignment
+#  AlignWith: variable
+
+Metrics/AbcSize:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#metricsabcsize
+  Max: 30
+
+Metrics/LineLength:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#metricslinelength
+  Max: 100
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # contaning a URI to be longer than Max.
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+
+Style/AlignHash:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylealignhash
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+
+# Disabled, see the YaST default at the end of the file
+#Style/AlignParameters:
+#  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylealignparameters
+#  Enabled: false
+
+Style/CollectionMethods:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylecollectionmethods
+  Enabled: false
+
+Style/EmptyLinesAroundBlockBody:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#styleemptylinesaroundblockbody
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylemultilineoperationindentation
+  EnforcedStyle: indented
+
 Style/StringLiterals:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylestringliterals
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#stylestringliteralsininterpolation
   EnforcedStyle: double_quotes
 
+Style/WordArray:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#deviations-from-the-upstream-style-guide
+  Enabled: false
+
+Style/RegexpLiteral:
+  StyleGuide: https://github.com/SUSE/style-guides/blob/master/Ruby.md#deviations-from-the-upstream-style-guide
+  Enabled: false
+
+Style/SignalException:
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  EnforcedStyle: only_raise
+
+
+################################################################################
+#
+# This part contains the YaST specific changes to the shared SUSE configuration
+#
+################################################################################
+
+# no extra indentation for multiline function calls
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+# no extra indentation for case
+Style/CaseIndentation:
+  IndentWhenRelativeTo: end
+
+# "unless" has a different connotation than "if not"
+Style/NegatedIf:
+  Enabled: false
+
+# allow more than 10 lines for methods
+Metrics/MethodLength:
+  Max: 30
+
+Metrics/ClassLength:
+  Max: 250

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "http://rubygems.org"
 
 gem "bicho", ">= 0.0.10"
 gem "ruby-trello", ">= 1.2"
+gem "rainbow", ">= 2.0.0"
+
+group :development do
+  gem "rubocop", "~> 0.29.1", require: false
+end

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ Tools to help with the YaST Trello boards.
 [t]: https://github.com/jeremytregunna/ruby-trello
 [p]: https://build.opensuse.org/package/show/openSUSE:Factory/python-bugzilla
 
+### Installation
+
+Install the `python-bugzilla` tool via `sudo zypper install python-bugzilla`.
+
+It is recommended to use bundler to install the Rubygems, run this in the Git
+checkout:
+
+```sh
+bundle install --path vendor/bundle
+```
+
+Then prefix the commands by `bundle exec`, e.g. `bundle exec ./check`.
+
 ### Setup
 
 **ruby-trello** reads the environment variables
@@ -61,3 +74,33 @@ create $BUG_NUMBER
 ```sh
 addurl 999999 https://trello.example.com/cards/my-first-card
 ```
+
+- **check** runs some validation checks and reports the found issues:
+
+  - It checks whether the YaST team bugs have a link to a Trello card (in the
+    **URL** field).
+  - It checks that all open YaST team bugs are tracked in Trello (i.e. a card
+    exists).
+  - Reports the Trello cards which refer to a closed bug in bugzilla. These
+    cards should be moved to *Done* or archived if the bug is not valid anymore.
+
+  The command supports a simple auto correction mode. In this mode it tries
+  to fix the found issues. Use `-a` or `--auto-correct` option to turn it on
+  (by default it is disabled).
+
+  Currently these auto correct actions are performed:
+
+  - The missing links from Bugzilla bugs to the Trello cards are added.
+  - Missing Trello cards are created
+
+  It is recommended to run it in read-only mode first to see the found issues:
+
+  ```sh
+  check
+  ```
+
+  If the reported changes are valid you can fix them by running:
+
+  ```sh
+  check -a
+  ```

--- a/check
+++ b/check
@@ -1,0 +1,223 @@
+#!/usr/bin/env ruby
+
+require "rainbow"
+require "optparse"
+
+require_relative "ytrello"
+
+# If a Trello card contains just a number without "FATE" (case insensitive)
+# it might be a FATE number instead of a bug number. Consider it as a possible
+# FATE number if it is below this limit.
+FATE_NUMBER_MAX = 400_000
+
+def parse_options
+  options = {}
+
+  op = OptionParser.new do |opts|
+    opts.banner =
+      "\nThis script checks whether the YaST Trello boards are in sync with the Bugzilla.\n\n" \
+      "The Trello credentials are read from the #{ENV_TRELLO_KEY} and #{ENV_TRELLO_TOKEN}\n" \
+      "environment variables. The Bugzilla credentials are read from the '~/.oscrc' file.\n\n" \
+      "Usage: #{$PROGRAM_NAME} [options]\n\n"
+
+    opts.on("-a", "--auto-correct", "Try to fix the detected problems, " \
+      "currently only the missing Trello cards are created") do
+
+      options[:auto_correct] = true
+    end
+
+    opts.on("-h", "--help", "Print this help") do
+      puts opts
+      exit 0
+    end
+  end
+
+  op.parse!
+
+  options
+end
+
+
+# query the bugs assigned to the YaST Team
+# @return [Hash<Symbol,Array<BichoBug>>] :all => all team bugs, :missing =>
+#   bugs with empty URL attribute, :unknown => the URL is set, but does not
+#   point to a Trello URL
+def check_team_bugs
+  missing_bugs = []
+  unknown_links = []
+
+  # ignore closed bugs
+  all_bugs = Bicho::Bug.where(assigned_to: BUGZILLA_ACCOUNT).select do |bug|
+    bug.resolution.empty?
+  end
+
+  all_bugs.each do |bug|
+    if bug["url"].nil? || bug["url"].empty?
+      missing_bugs << bug
+    elsif !bug["url"].start_with?("https://trello.com/")
+      unknown_links << bug
+    end
+  end
+
+  { all: all_bugs, missing: missing_bugs, unknown: unknown_links }
+end
+
+# read all Trello cards from the Incoming and the Team boards
+# @return [Array<Trello::Card>] found cards
+def trello_cards
+  inc_board  = Trello::Board.find(INC_BOARD_ID)  || raise
+  t1_board = Trello::Board.find(TEAM_1_BOARD_ID) || raise
+  ta_board = Trello::Board.find(TEAM_A_BOARD_ID) || raise
+
+  # [*] If you need to get all lists in a board:
+  # inc_board.lists.each {|l| puts "# #{l.name}\n\"#{l.id}\","}
+
+  to_array(inc_board.cards) + to_array(t1_board.cards) + to_array(ta_board.cards)
+end
+
+# @return [Hash<Fixnum,Trello::Card>] map bug ID => Trello card
+def find_trello_bugs
+  trello_bugs = {}
+
+  trello_cards.each do |card|
+    # skip cards not in the specified list
+    next unless CHECKED_LISTS.include?(card.list_id)
+
+    # TODO: skip FATE cards for now, maybe add a FATE check as well?
+    next if card.name.match(/\bfate\b/i)
+
+    # skip cards not containing any bug number
+    # expect bug numbers have 6 or 7 digits
+    next unless card.name.match(/\b#?(\d{6,7})\b/)
+
+    bug_id = Regexp.last_match[1].to_i
+    trello_bugs[bug_id] = card
+  end
+
+  trello_bugs
+end
+
+def find_closed_trello_bugs(found_trello_bugs)
+  closed_bugs = {}
+
+  Bicho.client.get_bugs(*found_trello_bugs.keys).each do |bug|
+    next if bug.resolution.empty?
+    closed_bugs[bug] = found_trello_bugs[bug.id]
+  end
+
+  closed_bugs
+end
+
+def print_bugzilla_summary(team_bugs)
+  team_bugs[:missing].each do |bug|
+    puts "Bug #{Rainbow(bug.url).yellow}: URL attribute not set"
+  end
+
+  team_bugs[:unknown].each do |bug|
+    puts "Bug #{Rainbow(bug.url).yellow}: URL \"#{bug["url"]}\"does not link to Trello "
+  end
+end
+
+# check if a number in Trello card label possibly refers to FATE instead of bugzilla
+def print_trello_fate_warnings(open_trello_bugs)
+  open_trello_bugs.each do |bug_id, card|
+    # enough high number or "bug" in the name
+    next if bug_id > FATE_NUMBER_MAX || card.name.match(/\bbug\b/i)
+
+    puts "#{Rainbow(card.short_url).yellow} - " \
+      "#{card.name.sub(bug_id.to_s, Rainbow(bug_id.to_s).magenta)}"
+    puts "Number #{Rainbow(bug_id).magenta} possibly refers to " \
+      "FATE, add \"FATE\" string if it is a feature number"
+    puts
+  end
+end
+
+def print_trello_closed_bugs(trello_closed_bugs)
+  trello_closed_bugs.each do |bug, card|
+    puts Rainbow(card.name).cyan
+    puts "#{Rainbow(card.short_url).yellow} refers to #{Rainbow(bug.url).yellow}" \
+      " resolved as #{Rainbow(bug.resolution).red}"
+    puts
+  end
+end
+
+def print_summary_line(line, ok)
+  puts Rainbow(line).color(ok ? :green : :red)
+end
+
+def print_summary(team_bugs, open_trello_bugs, closed_trello_bugs)
+  not_in_trello = bugs_not_in_trello(team_bugs, open_trello_bugs)
+
+  puts
+  print_summary_line("Found #{not_in_trello.size} bugs not in Trello", not_in_trello.empty?)
+  print_summary_line("Found #{team_bugs[:all].size} YaST Team bugs, " \
+    "#{team_bugs[:missing].size} do not link to Trello.", team_bugs[:missing].empty?)
+  print_summary_line("Found #{open_trello_bugs.size} bug cards in Trello, " \
+    "#{closed_trello_bugs.size} possibly refer to a closed bug.", closed_trello_bugs.empty?)
+  puts
+end
+
+def bugs_not_in_trello(team_bugs, open_trello_bugs)
+  team_bugs[:all].map(&:id) - open_trello_bugs.keys.map(&:to_i)
+end
+
+def print_not_in_trello(not_in_trello)
+  not_in_trello.each do |bug|
+    bug_url = "https://bugzilla.suse.com/#{bug}"
+    puts "Bug #{Rainbow(bug_url).yellow} is not tracked in Trello"
+  end
+end
+
+def print_result(team_bugs, open_trello_bugs, closed_trello_bugs)
+  not_in_trello = bugs_not_in_trello(team_bugs, open_trello_bugs)
+  print_not_in_trello(not_in_trello)
+  print_bugzilla_summary(team_bugs)
+  print_trello_fate_warnings(open_trello_bugs)
+  print_trello_closed_bugs(closed_trello_bugs)
+  print_summary(team_bugs, open_trello_bugs, closed_trello_bugs)
+end
+
+######################################################
+
+options = parse_options
+
+check_trello_credentials
+
+setup_bicho
+setup_trello
+
+puts "Reading the bugs assigned to #{BUGZILLA_ACCOUNT}..."
+team_bugs = check_team_bugs
+
+puts "Reading the YaST Trello cards..."
+trello_bugs = find_trello_bugs
+
+puts "Reading bugs referred in the YaST Trello cards..."
+closed_trello_bugs = find_closed_trello_bugs(trello_bugs)
+not_in_trello = bugs_not_in_trello(team_bugs, trello_bugs)
+
+print_result(team_bugs, trello_bugs, closed_trello_bugs)
+
+# no issue found
+exit 0 if team_bugs[:missing].empty? && closed_trello_bugs.empty? && not_in_trello.empty?
+
+# try fixing some problems
+if options[:auto_correct]
+  puts "Running autocorrection..."
+  create_script = File.expand_path("../create", __FILE__)
+
+  team_bugs[:missing].each do |bug|
+    puts "Creating a Trello card for bug ##{bug.id}..."
+    `#{create_script} #{bug.id}`
+  end
+
+  not_in_trello.each do |bug|
+    puts "Creating a Trello card for bug ##{bug}..."
+    `#{create_script} #{bug}`
+  end
+
+  # potentially fixed everything?
+  exit 0 if closed_trello_bugs.empty?
+end
+
+exit 1

--- a/create
+++ b/create
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require "English"
-require "trello"
+require_relative "ytrello"
 
 if ARGV.empty? || ARGV[0].include?("-h")
   puts "Usage: #{$PROGRAM_NAME} bug_number"
@@ -8,20 +8,8 @@ if ARGV.empty? || ARGV[0].include?("-h")
   exit 0
 end
 
-`bicho version 2>&1`
-unless $CHILD_STATUS.success?
-  puts "https://rubygems.org/gems/bicho >= 0.0.10 is required"
-  exit 1
-end
-
-Trello.configure do |config|
-  config.developer_public_key = ENV["TRELLO_DEVELOPER_PUBLIC_KEY"]
-  config.member_token         = ENV["TRELLO_MEMBER_TOKEN"]
-end
-
-def debug(s)
-  $stderr.puts s if $VERBOSE
-end
+setup_trello
+setup_bicho
 
 # abbreviate a SUSE product name
 def abbrev(s)
@@ -35,29 +23,25 @@ def abbrev(s)
     .tr(" ", "")
 end
 
-INC_BOARD_ID  = "5507f013b863aa041618871d" # Agile YaST Incoming Board
-TEAM_1_BOARD_ID = "5502d5dd8eb45fb4581c1a0f" # Agile YaST: Team 1
-TEAM_A_BOARD_ID = "557833ad6be7b9634f089201" # Agile YaST: Team A
-
 # in that board:
 PRODUCT_LISTS = {
-  /SLE[SD]12-SP1/   => "5502d6719b0d5db70bcf6655", # SLE12-SP1 development
-  /SLE[SD]12/       => "5507f04f2c885ffbdd53208a", # SLE12-maintenance
+  /SLE[SD]12-SP1/ => "5502d6719b0d5db70bcf6655", # SLE12-SP1 development
+  /SLE[SD]12/     => "5507f04f2c885ffbdd53208a", # SLE12-maintenance
   # not yet:
   # /SLE[SD]12-SP2/ => "5538994821027776154180eb",      # SLE12-SP2 development
   # /SLE[SD]12-SP1/ => "5507f04ba946797c971ecde3",      # SLE12-SP1 maintenance
-  /SLE[SD]11-SP4/   => "5507f0549c920252e89da5ad", # SLE11-SP4 development
-  /SLE[SD]11/       => "5507f140ab44b6bcfcc6c561", # SLE11-maintenance
-  /^oS/             => "550800984de3079fa9ded12a", # openSUSE
+  /SLE[SD]11-SP4/ => "5507f0549c920252e89da5ad", # SLE11-SP4 development
+  /SLE[SD]11/     => "5507f140ab44b6bcfcc6c561", # SLE11-maintenance
+  /^oS/           => "550800984de3079fa9ded12a", # openSUSE
   # fallback
-  /./               => "5507f28d31c1cfac7a83eb72"  # Generic Ideas
+  /./             => "5507f28d31c1cfac7a83eb72"  # Generic Ideas
 }
 
 def product_to_list(product)
   PRODUCT_LISTS.to_a.each do |pattern, list_id|
     return list_id if product =~ pattern
   end
-  fail "Internal error, PRODUCT_LISTS did not match"
+  raise "Internal error, PRODUCT_LISTS did not match"
 end
 
 def markdown_link(text, url)
@@ -65,39 +49,34 @@ def markdown_link(text, url)
 end
 
 def bz_markdown_link(id)
-  markdown_link("bsc##{id}", "https://bugzilla.suse.com/show_bug.cgi?id=#{id}")
+  markdown_link("bsc##{id}", "#{BUGZILLA_URL}/show_bug.cgi?id=#{id}")
 end
 
 def bicho_details(bug_id)
-  format = "%{summary}\n%{product}"
-  res = `bicho -b suse show -f '#{format}' #{bug_id}`
-  lines = res.split(/\n/)
-  { summary: lines[0], product: lines[1] }
+  bug = Bicho.client.get_bugs(bug_id).first
+  raise "Bug ##{bug_id} not found" unless bug
+  bug.priority.match(/^(\S+)\s/)
+  { summary: bug.summary, product: bug.product, priority: Regexp.last_match(1) }
 end
 
 bug_id      = ARGV[0]
 details     = bicho_details(bug_id)
 product     = abbrev(details[:product])
-card_name   = "#{product} ##{bug_id} #{details[:summary]}"
+card_name   = "#{product} (#{details[:priority]}) ##{bug_id} #{details[:summary]}"
 description = bz_markdown_link(bug_id)
 list_id     = product_to_list(product)
 # list_id     = "546336636415e12617f88e47" # My work / Done
 
 debug "Trello query"
-inc_board  = Trello::Board.find(INC_BOARD_ID)  || fail
-t1_board = Trello::Board.find(TEAM_1_BOARD_ID) || fail
-ta_board = Trello::Board.find(TEAM_A_BOARD_ID) || fail
+inc_board  = Trello::Board.find(INC_BOARD_ID)  || raise
+t1_board = Trello::Board.find(TEAM_1_BOARD_ID) || raise
+ta_board = Trello::Board.find(TEAM_A_BOARD_ID) || raise
 
 labels = inc_board.labels(false) # false: objects; true: names
-new_item_label = labels.find{|i| i.name =~ /new.item/i } || fail
+new_item_label = labels.find { |i| i.name =~ /new.item/i } || raise
 
-list = Trello::List.find(list_id) ||
-  fail("Cannot find list #{list_id} to represent #{details[:product]}")
-
-# Array#to_a -> Trello::MultiAssociation, WTF?!
-def to_array(a)
-  a.map {|i| i}
-end
+Trello::List.find(list_id) ||
+  raise("Cannot find list #{list_id} to represent #{details[:product]}")
 
 inc_cards  = to_array inc_board.cards
 t1_cards   = to_array t1_board.cards
@@ -111,17 +90,15 @@ card = nil
 if existing.empty?
   debug "Creating"
   card = Trello::Card.create(list_id: list_id,
-                             name: card_name,
-                             desc: description,
-                             pos: "top")
+                             name:    card_name,
+                             desc:    description,
+                             pos:     "top")
   card.add_label(new_item_label)
   puts "Created #{bug_id} => #{card.short_url}"
 else
   puts "Card for bug already exists:"
-  existing.each {|c| puts c.url}
-  if existing.size == 1
-    card = existing.first
-  end
+  existing.each { |c| puts c.url }
+  card = existing.first if existing.size == 1
 end
 
 if card

--- a/ytrello.rb
+++ b/ytrello.rb
@@ -1,0 +1,82 @@
+require "trello"
+require "bicho"
+
+# Trello board IDs
+INC_BOARD_ID  = "5507f013b863aa041618871d" # Agile YaST Incoming Board
+TEAM_1_BOARD_ID = "5502d5dd8eb45fb4581c1a0f" # Agile YaST: Team 1
+TEAM_A_BOARD_ID = "557833ad6be7b9634f089201" # Agile YaST: Team A
+
+# Trello list IDs, see [*] how to get the IDs
+CHECKED_LISTS = [
+  # Incoming board
+  # Backlog Team A
+  "5502d691d05c3b3817317566",
+  # SLE12-SP1 development
+  "5502d6719b0d5db70bcf6655",
+  # Generic Ideas
+  "5507f28d31c1cfac7a83eb72",
+  # SLE12-SP2 development
+  "5538994821027776154180eb",
+  # SLE-13
+  "55f921f1cc340f0d071fa4dc",
+  # SLE12-maintenance
+  "5507f04f2c885ffbdd53208a",
+  # SLE11-SP4 development
+  "5507f0549c920252e89da5ad",
+  # SLE11-maintenance
+  "5507f140ab44b6bcfcc6c561",
+  # openSUSE
+  "550800984de3079fa9ded12a",
+  # SLE12-SP1 maintenance
+  "5507f04ba946797c971ecde3",
+
+  # Team 1 boards
+  # Backlog Team 1
+  "557835b5cb9c13dcd032ecbb",
+  # Sprint Backlog
+  "5577ed07930f16fb224ca248",
+  # Doing
+  "5502d6b29a7a2ab8025a4c56",
+
+  # Team A boards
+  # Sprint Backlog
+  "5502d69d3e68ab3d1729337e",
+  # Doing
+  "557833dde4f1218b7d1cf831"
+]
+
+BUGZILLA_URL = "https://bugzilla.suse.com"
+BUGZILLA_ACCOUNT = "yast-internal@suse.de"
+
+ENV_TRELLO_KEY = "TRELLO_DEVELOPER_PUBLIC_KEY"
+ENV_TRELLO_TOKEN = "TRELLO_MEMBER_TOKEN"
+
+def check_trello_credentials
+  if !ENV[ENV_TRELLO_KEY] || !ENV[ENV_TRELLO_TOKEN]
+    $stderr.puts "Error: Pass the Trello credentials via #{ENV_TRELLO_KEY}" \
+    " and\n#{ENV_TRELLO_TOKEN} environment variables."
+    exit 1
+  end
+end
+
+# set the SUSE Bugzilla connection
+def setup_bicho
+  Bicho.client = Bicho::Client.new(BUGZILLA_URL)
+end
+
+# set the Trello credentials
+def setup_trello
+  Trello.configure do |config|
+    config.developer_public_key = ENV[ENV_TRELLO_KEY]
+    config.member_token         = ENV[ENV_TRELLO_TOKEN]
+  end
+end
+
+# Array#to_a -> Trello::MultiAssociation, WTF?!
+def to_array(a)
+  a.map { |i| i }
+end
+
+def debug(s)
+  $stderr.puts s if $VERBOSE
+end


### PR DESCRIPTION
The new `check` script checks for inconsistencies between Bugzilla and Trello.
#### Additional changes:
- updated README
- use the default YaST Rubocop config
- share the common code in `ytrello.rb`
- use the Rainbow gem for colorizing the output
#### Example output:

![check_output](https://cloud.githubusercontent.com/assets/907998/11962734/6f0d5a48-a8e2-11e5-8e0a-d7c18c2cfacf.png)
