### PR TITLE
Gemfile - use ruby-trello 1.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "bicho", ">= 0.0.10"
-gem "ruby-trello", ">= 1.2"
+gem "ruby-trello", "~> 1.3.0"
 gem "rainbow", ">= 2.0.0"
 
 group :development do


### PR DESCRIPTION
The new 1.4.x has some incompatible changes... :worried: 
