### PR TITLE
Automatic Bundler setup, add "Review" section

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,3 +96,8 @@ Metrics/MethodLength:
 
 Metrics/ClassLength:
   Max: 250
+
+AllCops:
+  # do not check the locally installed gems
+  Exclude:
+    - '.vendor/**/*'

--- a/README.md
+++ b/README.md
@@ -18,14 +18,8 @@ Tools to help with the YaST Trello boards.
 
 Install the `python-bugzilla` tool via `sudo zypper install python-bugzilla`.
 
-It is recommended to use bundler to install the Rubygems, run this in the Git
-checkout:
-
-```sh
-bundle install --path vendor/bundle
-```
-
-Then prefix the commands by `bundle exec`, e.g. `bundle exec ./check`.
+The Ytrello scripts automatically install the needed Ruby gems into the
+`.vendor` subdirectory during the first run using `bundler`.
 
 ### Setup
 

--- a/check
+++ b/check
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
+require_relative "ytrello"
+
 require "rainbow"
 require "optparse"
-
-require_relative "ytrello"
 
 # If a Trello card contains just a number without "FATE" (case insensitive)
 # it might be a FATE number instead of a bug number. Consider it as a possible

--- a/check
+++ b/check
@@ -83,7 +83,7 @@ def find_trello_bugs
     next unless CHECKED_LISTS.include?(card.list_id)
 
     # TODO: skip FATE cards for now, maybe add a FATE check as well?
-    next if card.name.match(/\bfate\b/i)
+    next if card.name.match(/\bfate\b/i) || card.name.match(/\bfeature\b/i)
 
     # skip cards not containing any bug number
     # expect bug numbers have 6 or 7 digits
@@ -98,8 +98,10 @@ end
 
 def find_closed_trello_bugs(found_trello_bugs)
   closed_bugs = {}
+  # ignore "small" numbers, they most probably refer to a feature
+  bugnumbers = found_trello_bugs.keys.select { |n| n > FATE_NUMBER_MAX }
 
-  Bicho.client.get_bugs(*found_trello_bugs.keys).each do |bug|
+  Bicho.client.get_bugs(*bugnumbers).each do |bug|
     next if bug.resolution.empty?
     closed_bugs[bug] = found_trello_bugs[bug.id]
   end

--- a/create
+++ b/create
@@ -59,11 +59,27 @@ def bicho_details(bug_id)
   { summary: bug.summary, product: bug.product, priority: Regexp.last_match(1) }
 end
 
+# create a card description text
+# @param bug_id bug number
+# @return [String] description text in the Markdown format
+def card_description(bug_id)
+  descr = <<EOT
+Bugzilla: #{bz_markdown_link(bug_id)}
+
+---
+## Review
+- Pull Request: *URL here*
+EOT
+
+  # just to avoid the trailing blank errors in the heredoc
+  descr + "- "
+end
+
 bug_id      = ARGV[0]
 details     = bicho_details(bug_id)
 product     = abbrev(details[:product])
 card_name   = "#{product} (#{details[:priority]}) ##{bug_id} #{details[:summary]}"
-description = bz_markdown_link(bug_id)
+description = card_description(bug_id)
 list_id     = product_to_list(product)
 # list_id     = "546336636415e12617f88e47" # My work / Done
 

--- a/ytrello.rb
+++ b/ytrello.rb
@@ -1,3 +1,18 @@
+# install missing gems using bundler
+bundler_dir =  File.expand_path("../.vendor", __FILE__)
+
+if !File.exist?(bundler_dir)
+  puts "Installing needed Rubygems to #{bundler_dir} ..."
+  require "shellwords"
+  if !system "bundle install --path #{Shellwords.escape(bundler_dir)}"
+    $stderr.puts "Installing the needed Ruby gems failed"
+    exit 1
+  end
+end
+
+require "rubygems"
+require "bundler/setup"
+
 require "trello"
 require "bicho"
 


### PR DESCRIPTION
Several nice enhancements:
- Added `bunder` autosetup - no need to run `bundle install` and use `bundle exec` prefix for the scripts.
- Improved "closed bugs" check to ignore possibly FATE numbers, do not treat them as bug numbers (less false positives).
- Add `Review` section into the created Trello cards to encourage developers to add the links and notes for the review meeting .
