### PR TITLE
Dockerize ytrello

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Gemfile.lock
 /.bundle/
 /vendor/
 /.vendor/
+oscrc
+trello-creds.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-Gemfile.lock
 /.bundle/
 /vendor/
 /.vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,3 +101,4 @@ AllCops:
   # do not check the locally installed gems
   Exclude:
     - '.vendor/**/*'
+    - 'vendor/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.1.7
   - 2.4.1
 script:
-  - rubocop
+  - bundle exec rubocop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM opensuse:42.3
+MAINTAINER Knut anderssen "kanderssen@suse.com"
+
+RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+    gcc libxml2-devel libxslt-devel make ruby2.2-devel ruby2.2-rubygem-bundler \
+    python-bugzilla ca-certificates gcc-c++ && zypper clean -a
+
+# Set Ruby 2.2 as the default version
+RUN ln -sf /usr/bin/ruby.ruby2.2 /usr/local/bin/ruby
+
+RUN mkdir -p /ytrello
+WORKDIR /ytrello
+
+COPY Gemfile .
+COPY Gemfile.lock .
+
+RUN bundle config --global build.nokogiri "--use-system-libraries"
+RUN bundle config --global path "/ytrello/.vendor"
+RUN bundler install
+
+COPY . /ytrello/
+COPY oscrc /root/.oscrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM opensuse:42.3
 MAINTAINER Knut anderssen "kanderssen@suse.com"
 
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-    gcc libxml2-devel libxslt-devel make ruby2.2-devel ruby2.2-rubygem-bundler \
+    gcc libxml2-devel libxslt-devel make ruby2.4-devel ruby2.4-rubygem-bundler \
     python-bugzilla ca-certificates gcc-c++ && zypper clean -a
 
 # Set Ruby 2.2 as the default version
-RUN ln -sf /usr/bin/ruby.ruby2.2 /usr/local/bin/ruby
+RUN ln -sf /usr/bin/ruby.ruby2.4 /usr/local/bin/ruby
 
 RUN mkdir -p /ytrello
 WORKDIR /ytrello

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,15 @@
 source "http://rubygems.org"
 
+# on openSUSE-42.3, which has /usr/bin/ruby -> ruby-2.1, use
+#  bundler.ruby2.4 install
+#  ruby.ruby2.4 $ytrello_tool
+
+# implied by xmlrpc (required by bicho), but it's better to state it upfront
+ruby "2.4.1" # argh, ">=2.4" does not work
+
 gem "bicho", ">= 0.0.10"
-
-# xmlrpc (required by bicho) has been extracted
-# to a separate gem since Ruby 2.4
-gem "xmlrpc" if RUBY_VERSION =~ /^2\.[4-9]\./
-
 gem "ruby-trello", "~> 1.3.0"
 gem "rainbow", ">= 2.0.0"
-
-# ruby-trello requires activemodel
-# activemodel-5 requires ruby-2.2
-# but an openSUSE-42.1 installation may have only ruby-2.1
-# so let's use an older version
-gem "activemodel", "< 5", require: false if RUBY_VERSION.start_with?("2.1.")
 
 group :development do
   gem "rubocop", "0.41.2", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,82 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (5.1.5)
+      activesupport (= 5.1.5)
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    bicho (0.0.16)
+      highline (~> 1.7.8)
+      inifile (~> 3.0.0)
+      nokogiri (~> 1.8.1)
+      trollop (~> 2.1.2)
+      xmlrpc (~> 0.3.0)
+    concurrent-ruby (1.0.5)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    highline (1.7.10)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    inifile (3.0.0)
+    json (2.1.0)
+    mime-types (2.99.3)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    netrc (0.11.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    oauth (0.4.7)
+    parser (2.5.0.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.1)
+    public_suffix (3.0.2)
+    rainbow (2.2.2)
+      rake
+    rake (12.3.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rubocop (0.41.2)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    ruby-trello (1.3.0)
+      activemodel (>= 3.2.0)
+      addressable (~> 2.3)
+      json
+      oauth (~> 0.4.5)
+      rest-client (~> 1.8.0)
+    thread_safe (0.3.6)
+    trollop (2.1.2)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
+    unicode-display_width (1.3.0)
+    xmlrpc (0.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bicho (>= 0.0.10)
+  rainbow (>= 2.0.0)
+  rubocop (= 0.41.2)
+  ruby-trello (~> 1.3.0)
+  xmlrpc
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ DEPENDENCIES
   rainbow (>= 2.0.0)
   rubocop (= 0.41.2)
   ruby-trello (~> 1.3.0)
-  xmlrpc
 
 BUNDLED WITH
    1.10.6

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,25 @@
+# YTrello Docker Configuration
+
+Before starting using ytrello with docker we need to at least configure our OSC and ytrello credentiales as documented below.
+
+### Copy your osc credentials as oscrc
+```cp ~/.oscrc /ytrello_path/oscrc```
+
+### Build ytrello
+`docker build -t ytrello .`
+
+### Add ytrello as an alias (recommended although not needed)
+
+```bash
+# Add to your .bashrc a ytrello alias and define the environment trello credentials
+export TRELLO_DEVELOPER_PUBLIC_KEY=ffffffffffffffffffffffffffffffff
+export TRELLO_MEMBER_TOKEN=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+alias ytrello="docker run -ti -e TRELLO_DEVELOPER_PUBLIC_KEY=$TRELLO_DEVELOPER_PUBLIC_KEY -e TRELLO_MEMBER_TOKEN=$TRELLO_MEMBER_TOKEN ytrello"
+```
+
+### Start using it
+
+```bash
+ytrello ./check
+ytrello ./create 1065...
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Tools to help with the YaST Trello boards.
 
 - Make cards for bugs in Bugzilla.suse.com
 
+## Use with Docker
+
+The use of ytrello with docker is documented [here](README-docker.md)
+
 ### Requirements
 
 - [bicho.gem][b] >= 0.0.10

--- a/ytrello.rb
+++ b/ytrello.rb
@@ -34,7 +34,7 @@ CHECKED_LISTS = [
   # SLE15 Storage development
   "59a3db0f0fac7c99d1808ae9",
   # SLE12-SP3 maintenance"
-  "5538994821027776154180eb",
+  "57cfdbcc9ae10f3d1fb996d3",
   # SLE12-SP2 development
   "5538994821027776154180eb",
   # Generic Ideas


### PR DESCRIPTION
Just an idea, the ytrello credentials could be copied also to /root/.config/ytrello-creds.yml instead of using environment variables.


## Copy your osc credentials as oscrc
```cp ~/.oscrc /ytrello_path/oscrc```

## Build ytrello 
`docker build -t ytrello .`

## Add ytrello as an alias

```bash
# Add to your .bashrc a ytrello alias and define the environment trello credentials
export TRELLO_DEVELOPER_PUBLIC_KEY=ffffffffffffffffffffffffffffffff
export TRELLO_MEMBER_TOKEN=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
alias ytrello="docker run -ti -e TRELLO_DEVELOPER_PUBLIC_KEY=$TRELLO_DEVELOPER_PUBLIC_KEY -e TRELLO_MEMBER_TOKEN=$TRELLO_MEMBER_TOKEN ytrello"
```

## Start using it
```bash
ytrello ./check
ytrello ./create 1065...
```
